### PR TITLE
Fixed issue with secrets using the alias as the kmsKey

### DIFF
--- a/config/manifest.js
+++ b/config/manifest.js
@@ -77,8 +77,15 @@ var SecretSettingsSchema = {
 	type: 'object',
 	properties: {
 		kmsKeyAlias: { type: 'string' },
+		kmsKeyId: { type: 'string' },
 	},
-	required: ['kmsKeyAlias'],
+	anyOf: [{
+		title: '{ kmsKeyAlias: string }',
+		required: ['kmsKeyAlias']
+	}, {
+		title: '{ kmsKeyId: string }',
+		required: ['kmsKeyId']
+	}],
 	additionalProperties: false
 };
 v.addSchema(SecretSettingsSchema);

--- a/lib/secret-tasks.js
+++ b/lib/secret-tasks.js
@@ -6,11 +6,13 @@
 
 var Q = require('q');
 var _ = require('lodash');
+var aws = require('aws-sdk');
 var logger = require('winston');
 var Credstash = require('nodecredstash');
 var yaddaSecret = require('@asymmetrik/yadda-secret');
 
 var IAM = require('./iam-tools');
+var kms = new aws.KMS();
 
 /**
  * Generate Credstash credential store
@@ -19,7 +21,7 @@ var IAM = require('./iam-tools');
  * @param {string} options.DeploymentCenter.name - Deployment center name
  * @param {string} options.DeploymentCenter.region - Deployment center region
  * @param {object} options.DeploymentCenter.secret - Secret options
- * @param {string} options.DeploymentCenter.secret.kmsKeyAlias - KMS Master Key Alias to encrypt/decrypt data
+ * @param {string} options.DeploymentCenter.secret.kmsKey - KMS Master Key to encrypt/decrypt data
  * @return {module.exports|Credstash}
  */
 function getCredentialStore(options){
@@ -27,7 +29,7 @@ function getCredentialStore(options){
 	var store = new Credstash({
 		table: tableDetails.name,
 		awsOpts: { region: tableDetails.region },
-		kmsKey: options.DeploymentCenter.secret.kmsKeyAlias,
+		kmsKey: options.DeploymentCenter.secret.kmsKey,
 	});
 	store.__name = tableDetails.name;
 	return store;
@@ -44,6 +46,48 @@ function getCredentialTableDetails(options){
 		name: options.DeploymentCenter.name+'-Secrets',
 		region: options.DeploymentCenter.region,
 	}
+}
+
+/**
+ * @description Get the correct kmsKey for creating a Credstash store
+ * @param {string} options.DeploymentCenter.secret.kmsKeyAlias - Alias for a KMS Key
+ * @param {string} options.DeploymentCenter.secret.kmsKeyId - KMS Key Id
+ * @return {object} options
+ */
+function getKMSKeyId(options = {}){
+	// if we have no options, secrets are not enabled, just return
+	if (!options.DeploymentCenter.secret)
+		return options;
+
+	var secretConfig = options.DeploymentCenter.secret;
+
+	// if we have a kmsKeyId, use that and return
+	if (secretConfig.kmsKeyId) {
+		secretConfig.kmsKey = secretConfig.kmsKeyId;
+		return options;
+	}
+
+	// If we have the alias, go look up the id since this is what
+	// we need to create a credstash store
+	var params = {};
+	return Q.ninvoke(kms, 'listAliases', params)
+		.then(function(data){
+			var aliases = data.Aliases;
+			// find our matching aliases
+			var match = aliases.find(function(alias) {
+				return alias.indexOf(`alias/${secretConfig.kmsKeyAlias}`) > -1;
+			});
+			// if we have no match, throw an error
+			if (!match) {
+				var message = `Unable to find kmsKey for alias ${secretConfig.kmsKeyAlias}.`
+				message += ' Make sure this is a valid alias and that you have access to it.';
+				throw new Error(message);
+			}
+
+			// Update the value and return our options
+			secretConfig.kmsKey = match.TargetKeyId;
+			return options
+		});
 }
 
 /**
@@ -235,6 +279,7 @@ exports.verify = function(options){
  */
 exports.setupSecretCenter = function(options){
 	return Q.when(options)
+		.then(getKMSKeyId(options))
 		.then(function(){
 			//Determine if secrets are enabled
 			if(!options.DeploymentCenter.secret)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@asymmetrik/yadda",
   "description": "Deployment tool for AWS ECS and ECR",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "main": "index.js",
   "author": "Asymmetrik, Ltd",
   "license": "MIT",


### PR DESCRIPTION
Currently when interacting with secrets via `yadda secret`, you'll get `invalidKeyId` errors. This is because in your Manifest.js, you specify a deployment center like below.

```javascript
DeploymentCenter:{
  secret: {
    kmsKeyAlias: '...'
  }
}
```

This kmsKeyAlias is being passed to Credstash as the kmsKey argument and when that tries to create an `aws.KMS` instance, it will fail. 

This update allows you to specify a `kmsKeyId` property or a `kmsKeyAlias` property. If you use the id, it is set as the kmsKey.  If you use the alias, it will look up all the aliases and find the matching one and set the target id for your alias as the kmsKey.  That key is then passed into Credstash which creates a valid secretStore.

If you do not specify either a `kmsKeyId` or a `kmsKeyAlias` the linter will throw an error and you won't be able to proceed until you remove the `secret` configuration or add the required properties.
