### PR TITLE
Update node lambda runtime

### DIFF
--- a/deployment-center/cloudformation.json
+++ b/deployment-center/cloudformation.json
@@ -79,7 +79,7 @@
 			"Type": "AWS::Lambda::Function",
 			"Properties": {
 				"Description": "Cron Job Executor for ECS Docker Deployments",
-				"Runtime": "nodejs4.3",
+				"Runtime": "nodejs8.10",
 				"Handler": "index.runCronJobs",
 				"Timeout": 59,
 				"MemorySize": 128,


### PR DESCRIPTION
updated node run-time version to 8.10, previous 4.3 is not longer supported by AWS.